### PR TITLE
Fixing s3 filename, was previously writing to wrong location

### DIFF
--- a/data_cleaning/create_datasets_for_website.ipynb
+++ b/data_cleaning/create_datasets_for_website.ipynb
@@ -144,7 +144,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Everett Wetchler 2018-12-02 01:06:11 CST\n",
+      "Everett Wetchler 2018-12-08 13:27:33 CST\n",
       "\n",
       "numpy 1.15.3\n",
       "pandas 0.23.4\n",
@@ -234,7 +234,8 @@
     "    with open(filename, 'w') as f:\n",
     "        f.write(json.dumps(compress(slim, id_col=config['ID_COL'])))\n",
     "    if s3_upload:\n",
-    "        write_to_s3(filename)\n",
+    "        s3_filename = prefix + config['OUTFILE_PREFIX'] + '_compressed.json'\n",
+    "        write_to_s3(s3_filename)\n",
     "    fullfile = OUTFOLDER + prefix + config['OUTFILE_PREFIX'] + '_full.csv'\n",
     "    print(\"Writing full file to \" + fullfile)\n",
     "    df.to_csv(fullfile, index=False)"


### PR DESCRIPTION
The compression notebook was writing the compressed files to a folder inside the compression bucket, instead of at the root.