### PR TITLE
Creating a new compressed format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 venv
+client_secret.json
+config.yaml
+.idea
 .ipynb_checkpoints/
 data/
 tmp/

--- a/data_cleaning/create_datasets_for_website.ipynb
+++ b/data_cleaning/create_datasets_for_website.ipynb
@@ -57,7 +57,7 @@
     "\n",
     "In order to write compressed and slider files to s3, set the environment variables COMPRESS_CDR_S3 and/or COMPRESS_OIS_S3 to 'TRUE' before running this notebook.\n",
     "\n",
-    "##### Author: Everett Wetchler (everett.wetchler@gmail.com) and Aiden Yang (alyang250@gmail.com)\n",
+    "##### Author: Everett Wetchler (everett.wetchler@gmail.com),  Aiden Yang (alyang250@gmail.com), and Dashiel Lopez Mendez (hi@dashiel.dev)\n",
     "\n",
     "## Edit this if you want to tweak what data ends up in the compressed file, or where it's written"
    ]
@@ -65,9 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "CONFIG_MAPPING = {\n",
@@ -79,9 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "OUTFOLDER = './'  # Where to write the resulting files\n",
@@ -146,26 +142,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 40,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The watermark extension is already loaded. To reload it, use:\n",
-      "  %reload_ext watermark\n",
-      "Everett Wetchler and Aiden Yang 2019-02-17 13:00:31 CST\n",
-      "\n",
-      "numpy 1.16.1\n",
-      "pandas 0.24.1\n",
-      "datadotworld 1.6.0\n",
-      "watermark 1.8.1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
+    "import gzip\n",
     "import os\n",
+    "import shutil\n",
     "import boto3\n",
     "import datadotworld as dw\n",
     "import numpy as np\n",
@@ -175,19 +158,17 @@
     "pd.set_option('display.max_rows', 100)\n",
     "pd.set_option('display.max_columns', 100)\n",
     "\n",
-    "%load_ext watermark\n",
-    "%watermark -a \"Everett Wetchler and Aiden Yang\" -d -t -z -w -p numpy,pandas,datadotworld"
+    "# %load_ext watermark\n",
+    "# %watermark -a \"Everett Wetchler Aiden Yang, and Dashiel Lopez Mendez\" -d -t -z -w -p numpy,pandas,datadotworld"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 20,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "def compress(df, id_col=None):\n",
+    "def compress_original(df, id_col=None):\n",
     "    js = {\n",
     "        'meta': {\n",
     "            'num_columns': len(df.columns),\n",
@@ -213,6 +194,40 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def compress_new(df, id_col=None):\n",
+    "    def get_age_group(age):\n",
+    "        if age == 'not given':\n",
+    "            return age\n",
+    "        elif age < 18:\n",
+    "            return 'under 18'\n",
+    "        elif age < 30:\n",
+    "            return '18 to 29'\n",
+    "        elif age < 40:\n",
+    "            return '30 to 39'\n",
+    "        elif age < 50:\n",
+    "            return '40 to 49'\n",
+    "        elif age < 60:\n",
+    "            return '50 to 59'\n",
+    "        else:\n",
+    "            return '60 and up'\n",
+    "\n",
+    "    js = {'records': {}}\n",
+    "    if id_col:\n",
+    "        df = df.drop(id_col, axis=1)\n",
+    "    for col in df.columns:\n",
+    "        js['records'][col] = df[col].fillna('not given').tolist()\n",
+    "        if col in ('age_at_time_of_death', 'civilian_age', 'officer_age'):\n",
+    "            js['records']['age_group'] = df[col].apply(lambda x: get_age_group(x)).tolist()\n",
+    "\n",
+    "    return js"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 8,
    "metadata": {
     "collapsed": true
@@ -228,15 +243,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 41,
+   "metadata": {},
    "outputs": [],
    "source": [
     "def create_one(config, sample=False, s3_upload=False, accum_slider_data=None):\n",
     "    datasets = dw.load_dataset(config['DW_PROJECT_KEY'], force_update=True)\n",
     "    df = datasets.dataframes[config['DW_FILENAME']]\n",
+    "\n",
     "    slim = df.copy()\n",
     "    slim['year'] = pd.to_datetime(slim[config['DATE_COL']]).dt.year\n",
     "    slim = slim[config['KEEP_COLS']]\n",
@@ -246,13 +260,25 @@
     "        slim = slim.sample(5)\n",
     "        prefix = \"SAMPLE_\"\n",
     "    \n",
-    "    compressed = compress(slim, id_col=config['ID_COL'])\n",
+    "    compressed = compress_original(slim, id_col=config['ID_COL'])\n",
+    "    compressed_new = compress_new(slim, id_col=config['ID_COL'])\n",
     "    # Write\n",
     "    if not s3_upload:\n",
     "        filename = OUTFOLDER + prefix + config['OUTFILE_PREFIX'] + '_compressed.json'\n",
     "        print(\"Writing file to\", filename)\n",
     "        with open(filename, 'w') as f:\n",
     "            f.write(json.dumps(compressed))\n",
+    "\n",
+    "        filename = OUTFOLDER + prefix + config['OUTFILE_PREFIX'] + '_compressed_new.json'\n",
+    "        print(\"Writing file to\", filename)\n",
+    "        with open(filename, 'w') as f:\n",
+    "            f.write(json.dumps(compressed_new))\n",
+    "\n",
+    "        filename = OUTFOLDER + prefix + config['OUTFILE_PREFIX'] + '_compressed_new.json'\n",
+    "        print(\"Writing file to\", filename + '.gz')\n",
+    "        with open(filename, 'rb') as f_in, gzip.open(filename + '.gz', 'wb') as f_out:\n",
+    "            shutil.copyfileobj(f_in, f_out)\n",
+    "\n",
     "        fullfile = OUTFOLDER + prefix + config['OUTFILE_PREFIX'] + '_full.csv'\n",
     "        print(\"Writing file to \" + fullfile)\n",
     "        df.to_csv(fullfile, index=False)\n",
@@ -266,21 +292,28 @@
     "        s3_filename = prefix + config['OUTFILE_PREFIX'] + '_compressed.json'\n",
     "        print(\"Uploading file \" + s3_filename + \" to s3\")\n",
     "        s3.Bucket(S3_BUCKET_NAME).upload_file(s3_filename, s3_filename)\n",
-    "   "
+    "\n",
+    "        s3_filename = prefix + config['OUTFILE_PREFIX'] + '_compressed_new.json'\n",
+    "        print(\"Uploading file \" + s3_filename + \" to s3\")\n",
+    "        s3.Bucket(S3_BUCKET_NAME).upload_file(s3_filename, s3_filename)\n",
+    "                     \n",
+    "        s3_filename = prefix + config['OUTFILE_PREFIX'] + '_compressed_new.json.gz'\n",
+    "        print(\"Uploading file \" + s3_filename + \" to s3\")\n",
+    "        s3.Bucket(S3_BUCKET_NAME).upload_file(s3_filename, s3_filename)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## For local development"
+    "## Write the files"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 42,
    "metadata": {
-    "scrolled": true
+    "scrolled": false
    },
    "outputs": [
     {
@@ -289,18 +322,30 @@
      "text": [
       "cdr\n",
       "Writing file to ./SAMPLE_cdr_compressed.json\n",
+      "Writing file to ./SAMPLE_cdr_compressed_new.json\n",
+      "Writing file to ./SAMPLE_cdr_compressed_new.json.gz\n",
       "Writing file to ./SAMPLE_cdr_full.csv\n",
       "Writing file to ./cdr_compressed.json\n",
+      "Writing file to ./cdr_compressed_new.json\n",
+      "Writing file to ./cdr_compressed_new.json.gz\n",
       "Writing file to ./cdr_full.csv\n",
       "ois-civilians\n",
       "Writing file to ./SAMPLE_ois_compressed.json\n",
+      "Writing file to ./SAMPLE_ois_compressed_new.json\n",
+      "Writing file to ./SAMPLE_ois_compressed_new.json.gz\n",
       "Writing file to ./SAMPLE_ois_full.csv\n",
       "Writing file to ./ois_compressed.json\n",
+      "Writing file to ./ois_compressed_new.json\n",
+      "Writing file to ./ois_compressed_new.json.gz\n",
       "Writing file to ./ois_full.csv\n",
       "ois-officers\n",
       "Writing file to ./SAMPLE_ois_officers_compressed.json\n",
+      "Writing file to ./SAMPLE_ois_officers_compressed_new.json\n",
+      "Writing file to ./SAMPLE_ois_officers_compressed_new.json.gz\n",
       "Writing file to ./SAMPLE_ois_officers_full.csv\n",
       "Writing file to ./ois_officers_compressed.json\n",
+      "Writing file to ./ois_officers_compressed_new.json\n",
+      "Writing file to ./ois_officers_compressed_new.json.gz\n",
       "Writing file to ./ois_officers_full.csv\n"
      ]
     }
@@ -350,9 +395,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "tji",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "tji"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -364,7 +409,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In addition to the current compressed files, we're now pushing these new-format files that are about three times bigger, but also easier to parse. We're also including a new `age_group` column, highlighted in this sample:

<img width="910" alt="Screen Shot 2019-09-08 at 6 49 58 PM" src="https://user-images.githubusercontent.com/20423536/64496373-e3fe3e80-d269-11e9-9d87-b0f7417ffa2f.png">

Notice that the new files have `_new` appended to the name.

But wait, there's more! We're also pushing a compressed (`gzip`) version of those new-format files. As you can see in the image below, they're teeny-tiny, even more so than the old-format files; 86% smaller in the case of the CDR reports!

<img width="321" alt="Screen Shot 2019-09-08 at 6 36 26 PM" src="https://user-images.githubusercontent.com/20423536/64496387-0ee89280-d26a-11e9-94f1-aff8fbe8e2c8.png">

Either version can be used but I highly recommend using the gzipped version, since the user's browser will need to download these files locally. That would require ungzipping the file first. I can help with implementing that if needed.

Closes https://github.com/texas-justice-initiative/website/issues/216.